### PR TITLE
fix: security hardening + race condition resolution

### DIFF
--- a/packages/dynos_sync/lib/src/queue_store.dart
+++ b/packages/dynos_sync/lib/src/queue_store.dart
@@ -12,6 +12,9 @@ abstract class QueueStore {
   /// Get pending (un-synced) entries, oldest first.
   Future<List<SyncEntry>> getPending({int limit = 50});
 
+  /// Check if a specific record has a pending sync entry.
+  Future<bool> hasPending(String table, String id);
+
   /// Mark an entry as successfully synced.
   Future<void> markSynced(String id);
 

--- a/packages/dynos_sync/lib/src/sync_engine.dart
+++ b/packages/dynos_sync/lib/src/sync_engine.dart
@@ -123,9 +123,15 @@ class SyncEngine {
       final pulls = <Future<void>>[];
       for (final table in tables) {
         final remoteTime = remoteTs[table];
-        if (remoteTime == null) continue;
-
         final localTime = await timestamps.get(table);
+
+        if (remoteTime == null) {
+          // No remote timestamp info — pull with last known local timestamp
+          // (epoch if never synced). Ensures sync works without a sync_status table.
+          pulls.add(_pullTable(table, localTime));
+          continue;
+        }
+
         if (remoteTime.isAfter(localTime)) {
           pulls.add(_pullTable(table, localTime));
         }

--- a/packages/dynos_sync/lib/src/sync_engine.dart
+++ b/packages/dynos_sync/lib/src/sync_engine.dart
@@ -144,6 +144,12 @@ class SyncEngine {
       for (final row in rows) {
         final id = row['id']?.toString();
         if (id == null) continue;
+
+        // Skip overwriting local data if there is a pending user edit.
+        // This ensures un-synced local changes are not obliterated by incoming remote data.
+        final isPending = await queue.hasPending(table, id);
+        if (isPending) continue;
+
         await local.upsert(table, id, row);
       }
       await timestamps.set(table, DateTime.now().toUtc());

--- a/packages/dynos_sync/lib/src/timestamp_store.dart
+++ b/packages/dynos_sync/lib/src/timestamp_store.dart
@@ -10,7 +10,11 @@ abstract class TimestampStore {
   Future<void> set(String table, DateTime timestamp);
 }
 
-/// In-memory timestamp store. Useful for testing.
+/// In-memory timestamp store.
+///
+/// **WARNING:** Do not use this in production! It resets on app launch,
+/// which will cause a massive full data pull (`pullSince` epoch) every time.
+/// Highly recommended for testing purposes only.
 class InMemoryTimestampStore implements TimestampStore {
   final _timestamps = <String, DateTime>{};
 

--- a/packages/dynos_sync_drift/lib/src/drift_local_store.dart
+++ b/packages/dynos_sync_drift/lib/src/drift_local_store.dart
@@ -15,20 +15,22 @@ class DriftLocalStore implements LocalStore {
   @override
   Future<void> upsert(String table, String id, Map<String, dynamic> data) async {
     // Build column list and placeholders from the data map
-    final columns = data.keys.toList();
+    final columns = data.keys.map((c) => '"${c.replaceAll('"', '""')}"').toList();
+    final safeTable = '"${table.replaceAll('"', '""')}"';
     final placeholders = List.filled(columns.length, '?').join(', ');
     final values = data.values.toList();
 
     await _db.customStatement(
-      'INSERT OR REPLACE INTO $table (${columns.join(', ')}) VALUES ($placeholders)',
+      'INSERT OR REPLACE INTO $safeTable (${columns.join(', ')}) VALUES ($placeholders)',
       values,
     );
   }
 
   @override
   Future<void> delete(String table, String id) async {
+    final safeTable = '"${table.replaceAll('"', '""')}"';
     await _db.customStatement(
-      'DELETE FROM $table WHERE id = ?',
+      'DELETE FROM $safeTable WHERE id = ?',
       [id],
     );
   }

--- a/packages/dynos_sync_drift/lib/src/drift_queue_store.dart
+++ b/packages/dynos_sync_drift/lib/src/drift_queue_store.dart
@@ -40,6 +40,16 @@ class DriftQueueStore implements QueueStore {
   }
 
   @override
+  Future<bool> hasPending(String table, String id) async {
+    final rows = await _db.customSelect(
+      'SELECT COUNT(1) AS c FROM dynos_sync_queue WHERE table_name = ? AND record_id = ? AND synced_at IS NULL',
+      variables: [Variable.withString(table), Variable.withString(id)],
+    ).get();
+    
+    return rows.first.read<int>('c') > 0;
+  }
+
+  @override
   Future<void> markSynced(String id) async {
     await _db.customStatement(
       'UPDATE dynos_sync_queue SET synced_at = ? WHERE id = ?',

--- a/packages/dynos_sync_supabase/.dart_tool/package_graph.json
+++ b/packages/dynos_sync_supabase/.dart_tool/package_graph.json
@@ -13,51 +13,6 @@
       "devDependencies": []
     },
     {
-      "name": "dynos_sync",
-      "version": "0.1.0",
-      "dependencies": [
-        "meta",
-        "uuid"
-      ]
-    },
-    {
-      "name": "meta",
-      "version": "1.18.2",
-      "dependencies": []
-    },
-    {
-      "name": "uuid",
-      "version": "4.5.3",
-      "dependencies": [
-        "crypto",
-        "fixnum"
-      ]
-    },
-    {
-      "name": "fixnum",
-      "version": "1.1.1",
-      "dependencies": []
-    },
-    {
-      "name": "crypto",
-      "version": "3.0.7",
-      "dependencies": [
-        "typed_data"
-      ]
-    },
-    {
-      "name": "typed_data",
-      "version": "1.4.0",
-      "dependencies": [
-        "collection"
-      ]
-    },
-    {
-      "name": "collection",
-      "version": "1.19.1",
-      "dependencies": []
-    },
-    {
       "name": "supabase",
       "version": "2.10.2",
       "dependencies": [
@@ -73,11 +28,29 @@
       ]
     },
     {
+      "name": "dynos_sync",
+      "version": "0.1.0",
+      "dependencies": [
+        "meta",
+        "uuid"
+      ]
+    },
+    {
+      "name": "logging",
+      "version": "1.3.0",
+      "dependencies": []
+    },
+    {
       "name": "yet_another_json_isolate",
       "version": "2.1.0",
       "dependencies": [
         "async"
       ]
+    },
+    {
+      "name": "rxdart",
+      "version": "0.28.0",
+      "dependencies": []
     },
     {
       "name": "storage_client",
@@ -113,6 +86,16 @@
       ]
     },
     {
+      "name": "http",
+      "version": "1.6.0",
+      "dependencies": [
+        "async",
+        "http_parser",
+        "meta",
+        "web"
+      ]
+    },
+    {
       "name": "gotrue",
       "version": "2.18.0",
       "dependencies": [
@@ -138,14 +121,25 @@
       ]
     },
     {
-      "name": "jwt_decode",
-      "version": "0.3.1",
+      "name": "meta",
+      "version": "1.18.2",
       "dependencies": []
     },
     {
-      "name": "logging",
-      "version": "1.3.0",
-      "dependencies": []
+      "name": "uuid",
+      "version": "4.5.3",
+      "dependencies": [
+        "crypto",
+        "fixnum"
+      ]
+    },
+    {
+      "name": "async",
+      "version": "2.13.0",
+      "dependencies": [
+        "collection",
+        "meta"
+      ]
     },
     {
       "name": "retry",
@@ -153,8 +147,8 @@
       "dependencies": []
     },
     {
-      "name": "rxdart",
-      "version": "0.28.0",
+      "name": "mime",
+      "version": "2.0.0",
       "dependencies": []
     },
     {
@@ -168,21 +162,25 @@
       ]
     },
     {
+      "name": "web_socket_channel",
+      "version": "3.0.3",
+      "dependencies": [
+        "async",
+        "crypto",
+        "stream_channel",
+        "web",
+        "web_socket"
+      ]
+    },
+    {
+      "name": "collection",
+      "version": "1.19.1",
+      "dependencies": []
+    },
+    {
       "name": "web",
       "version": "1.1.1",
       "dependencies": []
-    },
-    {
-      "name": "mime",
-      "version": "2.0.0",
-      "dependencies": []
-    },
-    {
-      "name": "string_scanner",
-      "version": "1.4.1",
-      "dependencies": [
-        "source_span"
-      ]
     },
     {
       "name": "dart_jsonwebtoken",
@@ -195,12 +193,63 @@
       ]
     },
     {
-      "name": "pointycastle",
-      "version": "4.0.0",
+      "name": "jwt_decode",
+      "version": "0.3.1",
+      "dependencies": []
+    },
+    {
+      "name": "crypto",
+      "version": "3.0.7",
+      "dependencies": [
+        "typed_data"
+      ]
+    },
+    {
+      "name": "fixnum",
+      "version": "1.1.1",
+      "dependencies": []
+    },
+    {
+      "name": "typed_data",
+      "version": "1.4.0",
+      "dependencies": [
+        "collection"
+      ]
+    },
+    {
+      "name": "string_scanner",
+      "version": "1.4.1",
+      "dependencies": [
+        "source_span"
+      ]
+    },
+    {
+      "name": "source_span",
+      "version": "1.10.2",
       "dependencies": [
         "collection",
-        "convert"
+        "path",
+        "term_glyph"
       ]
+    },
+    {
+      "name": "web_socket",
+      "version": "1.0.1",
+      "dependencies": [
+        "web"
+      ]
+    },
+    {
+      "name": "stream_channel",
+      "version": "2.1.4",
+      "dependencies": [
+        "async"
+      ]
+    },
+    {
+      "name": "clock",
+      "version": "1.1.2",
+      "dependencies": []
     },
     {
       "name": "ed25519_edwards",
@@ -220,32 +269,11 @@
       ]
     },
     {
-      "name": "clock",
-      "version": "1.1.2",
-      "dependencies": []
-    },
-    {
-      "name": "adaptive_number",
-      "version": "1.0.0",
-      "dependencies": [
-        "fixnum"
-      ]
-    },
-    {
-      "name": "async",
-      "version": "2.13.0",
+      "name": "pointycastle",
+      "version": "4.0.0",
       "dependencies": [
         "collection",
-        "meta"
-      ]
-    },
-    {
-      "name": "source_span",
-      "version": "1.10.2",
-      "dependencies": [
-        "collection",
-        "path",
-        "term_glyph"
+        "convert"
       ]
     },
     {
@@ -259,38 +287,10 @@
       "dependencies": []
     },
     {
-      "name": "web_socket_channel",
-      "version": "3.0.3",
+      "name": "adaptive_number",
+      "version": "1.0.0",
       "dependencies": [
-        "async",
-        "crypto",
-        "stream_channel",
-        "web",
-        "web_socket"
-      ]
-    },
-    {
-      "name": "web_socket",
-      "version": "1.0.1",
-      "dependencies": [
-        "web"
-      ]
-    },
-    {
-      "name": "stream_channel",
-      "version": "2.1.4",
-      "dependencies": [
-        "async"
-      ]
-    },
-    {
-      "name": "http",
-      "version": "1.6.0",
-      "dependencies": [
-        "async",
-        "http_parser",
-        "meta",
-        "web"
+        "fixnum"
       ]
     }
   ],

--- a/packages/dynos_sync_supabase/lib/src/supabase_remote_store.dart
+++ b/packages/dynos_sync_supabase/lib/src/supabase_remote_store.dart
@@ -21,7 +21,8 @@ class SupabaseRemoteStore implements RemoteStore {
   /// Creates a Supabase remote store.
   ///
   /// - [client]: Your Supabase client instance.
-  /// - [userId]: The authenticated user's ID (used for sync_status lookup).
+  /// - [userId]: Callback that returns the current authenticated user's ID.
+  ///   Called on every sync cycle so it stays fresh across sign-out/sign-in.
   /// - [syncStatusTable]: Name of the sync status table (default: `sync_status`).
   /// - [tableTimestampKeys]: Maps table names to their `sync_status` column names.
   ///   Example: `{'users': 'users_at', 'tasks': 'tasks_at'}`.
@@ -34,7 +35,9 @@ class SupabaseRemoteStore implements RemoteStore {
   });
 
   final SupabaseClient client;
-  final String userId;
+  /// Returns the current user ID. Called per sync cycle to handle
+  /// session expiry and account switches.
+  final String Function() userId;
   final String syncStatusTable;
 
   /// Maps table names to their corresponding column in [syncStatusTable].
@@ -75,7 +78,7 @@ class SupabaseRemoteStore implements RemoteStore {
       final rows = await client
           .from(syncStatusTable)
           .select()
-          .eq('user_id', userId);
+          .eq('user_id', userId());
 
       if (rows.isEmpty) return {};
 

--- a/packages/dynos_sync_supabase/lib/src/supabase_remote_store.dart
+++ b/packages/dynos_sync_supabase/lib/src/supabase_remote_store.dart
@@ -90,9 +90,10 @@ class SupabaseRemoteStore implements RemoteStore {
       }
 
       return result;
-    } catch (_) {
-      // sync_status table doesn't exist or query failed — pull everything
-      return {};
+    } catch (e) {
+      // Let exceptions bubble up so the SyncEngine can catch and log them,
+      // avoiding a silent fallback to full-syncs.
+      rethrow;
     }
   }
 }

--- a/security_and_improvements_report.md
+++ b/security_and_improvements_report.md
@@ -1,0 +1,54 @@
+# Security and Improvement Report: `dynos_sync`
+
+Based on a review of the complete `dynos_sync` codebase (including the newly added engine and adapter implementations), here are the identified security leaks, architectural issues, and suggested improvements:
+
+## 🚨 Critical Security Leaks
+
+### 1. Massive SQL Injection Vulnerability (`DriftLocalStore`)
+The `DriftLocalStore.upsert` method constructs a raw SQL query by directly interpolating the `table` name and `data.keys` (columns) without escaping or sanitizing them:
+```dart
+final columns = data.keys.toList();
+await _db.customStatement(
+  'INSERT OR REPLACE INTO $table (${columns.join(', ')}) VALUES ($placeholders)',
+  values,
+);
+```
+**Risk:** This is a textbook SQL injection vulnerability. If a malicious payload is pulled from a compromised remote server, or if a user inputs a malicious dictionary key (e.g. `{"id) VALUES (1); DROP TABLE users; --": "value"}`), it will execute arbitrary SQL on the device, leading to complete local database destruction or data exfiltration.
+**Improvement:** You must properly escape column and table names by wrapping them in double-quotes (`"${col}"`), or strictly validate them against a schema allowlist before constructing the query.
+
+---
+
+## 🔒 Additional Security Risks
+
+### 2. Lack of Encryption at Rest (Local Storage)
+The `LocalStore` and `QueueStore` interfaces deal with raw `Map<String, dynamic>` payloads. 
+**Risk:** If a developer uses a standard SQLite/Drift database, the synced data sits unencrypted on the device. Malicious actors with physical access or relying on local exploits could read sensitive queued data.
+**Improvement:** Introduce encryption hooks or a `PayloadSerializer` interface in `SyncConfig` so developers can encrypt data before it is written to the local queue.
+
+### 3. Authentication State and Token Expiry
+The `SupabaseRemoteStore` holds a fixed client and `userId` context limit.
+**Risk:** If a user's session expires during a background sync, or if users switch accounts on the same device, the `SyncEngine` might attempt to push data to the wrong user's remote, or fail with unhandled auth errors, potentially leaving sensitive data stuck in the queue.
+**Improvement:** Provide a mechanism to inject or refresh authentication context dynamically per sync cycle.
+
+### 4. No Schema Validation at the Queue Level
+**Risk:** Without schema validation before enqueueing, malformed or malicious data can be queued. 
+**Improvement:** The client should enforce schema validation before enqueueing to prevent poisoned queues that will consistently fail remote validation.
+
+---
+
+## 🛠 Architectural / Logical Flaws
+
+### 5. Critical Race Condition: Overwriting Un-synced Local Edits
+In `SyncEngine._pullTable`, incoming remote rows unconditionally invoke `local.upsert(table, id, row)`, overwriting whatever is in the local database.
+**Risk:** If a user makes an offline edit (queued locally) and then launches the app, `pullAll` might run before `drain` finishes. The remote pull will overwrite the user's un-synced local edit on the UI layer. However, because the queue still holds a snapshot of the user's edit, it will eventually push that older snapshot to the server, overriding the newer remote data.
+**Improvement:** Implement conflict resolution. Before `local.upsert` in a pull, the engine should check `queue.getPending()` for that specific `table` and `id`. If a pending write exists, either ignore the incoming remote change (Client-Wins) or handle the merge appropriately. 
+
+### 6. Swallowed Errors in `SupabaseRemoteStore`
+In `getRemoteTimestamps()`, any exception retrieving timestamps is caught and silently ignored: `catch (_) { return {}; }`.
+**Risk:** A misconfigured trigger or transient network failure will be silently swallowed. The engine will fallback to returning an empty map, which causes `SyncEngine.pullAll` to perform a full sync (`pullSince(epoch)`) for every table. This will cause massive, unexpected bandwidth spikes and server load.
+**Improvement:** Log the error or rethrow it in a way that respects `SyncConfig.stopOnFirstError`, rather than silently degrading into expensive full syncs.
+
+### 7. `InMemoryTimestampStore` Risk in Production
+`InMemoryTimestampStore` resets on every app launch.
+**Risk:** If accidentally used in production, the engine will assume it has never synced and will attempt a full data pull every time the app opens.
+**Improvement:** Add a highly visible `@visibleForTesting` annotation or move it to a purely testing package.


### PR DESCRIPTION
## Summary
- Fix SQL injection vulnerability in `DriftLocalStore` (escape table/column names)
- Fix pull race condition — skip overwriting records with pending local edits
- Fix swallowed errors in `SupabaseRemoteStore.getRemoteTimestamps()` — rethrow instead of silent fallback
- Make `userId` a `String Function()` callback to handle session expiry and account switches
- Restore `pullAll()` fallback for tables without remote timestamps
- Add `InMemoryTimestampStore` production warning
- Add `hasPending()` to `QueueStore` interface

## Test plan
- [ ] Verify SQL injection is blocked (malicious column/table names)
- [ ] Verify pending local edits survive a pull cycle
- [ ] Verify auth expiry doesn't push to wrong user
- [ ] Verify sync works without a `sync_status` table

🤖 Generated with [Claude Code](https://claude.com/claude-code)