### PR TITLE
fix: security hardening + race condition resolution

### DIFF
--- a/lib/src/adapters/drift_local_store.dart
+++ b/lib/src/adapters/drift_local_store.dart
@@ -14,20 +14,22 @@ class DriftLocalStore implements LocalStore {
 
   @override
   Future<void> upsert(String table, String id, Map<String, dynamic> data) async {
-    final columns = data.keys.toList();
+    final columns = data.keys.map((c) => '"${c.replaceAll('"', '""')}"').toList();
+    final safeTable = '"${table.replaceAll('"', '""')}"';
     final placeholders = List.filled(columns.length, '?').join(', ');
     final values = data.values.toList();
 
     await _db.customStatement(
-      'INSERT OR REPLACE INTO $table (${columns.join(', ')}) VALUES ($placeholders)',
+      'INSERT OR REPLACE INTO $safeTable (${columns.join(', ')}) VALUES ($placeholders)',
       values,
     );
   }
 
   @override
   Future<void> delete(String table, String id) async {
+    final safeTable = '"${table.replaceAll('"', '""')}"';
     await _db.customStatement(
-      'DELETE FROM $table WHERE id = ?',
+      'DELETE FROM $safeTable WHERE id = ?',
       [id],
     );
   }

--- a/lib/src/adapters/drift_queue_store.dart
+++ b/lib/src/adapters/drift_queue_store.dart
@@ -40,6 +40,16 @@ class DriftQueueStore implements QueueStore {
   }
 
   @override
+  Future<bool> hasPending(String table, String id) async {
+    final rows = await _db.customSelect(
+      'SELECT COUNT(1) AS c FROM dynos_sync_queue '
+      'WHERE table_name = ? AND record_id = ? AND synced_at IS NULL',
+      variables: [Variable.withString(table), Variable.withString(id)],
+    ).get();
+    return rows.first.read<int>('c') > 0;
+  }
+
+  @override
   Future<void> markSynced(String id) async {
     await _db.customStatement(
       'UPDATE dynos_sync_queue SET synced_at = ? WHERE id = ?',

--- a/lib/src/adapters/supabase_remote_store.dart
+++ b/lib/src/adapters/supabase_remote_store.dart
@@ -20,7 +20,8 @@ class SupabaseRemoteStore implements RemoteStore {
   /// Creates a Supabase remote store.
   ///
   /// - [client]: Your Supabase client instance.
-  /// - [userId]: The authenticated user's ID.
+  /// - [userId]: Callback that returns the current authenticated user's ID.
+  ///   Called on every sync cycle so it stays fresh across sign-out/sign-in.
   /// - [syncStatusTable]: Name of the sync status table (default: `sync_status`).
   /// - [tableTimestampKeys]: Maps table names to their `sync_status` column names.
   ///   Example: `{'tasks': 'tasks_at', 'notes': 'notes_at'}`.
@@ -32,7 +33,10 @@ class SupabaseRemoteStore implements RemoteStore {
   });
 
   final SupabaseClient client;
-  final String userId;
+
+  /// Returns the current user ID. Called per sync cycle to handle
+  /// session expiry and account switches.
+  final String Function() userId;
   final String syncStatusTable;
   final Map<String, String> tableTimestampKeys;
 
@@ -71,7 +75,7 @@ class SupabaseRemoteStore implements RemoteStore {
       final rows = await client
           .from(syncStatusTable)
           .select()
-          .eq('user_id', userId);
+          .eq('user_id', userId());
 
       if (rows.isEmpty) return {};
 
@@ -86,8 +90,10 @@ class SupabaseRemoteStore implements RemoteStore {
       }
 
       return result;
-    } catch (_) {
-      return {};
+    } catch (e) {
+      // Rethrow so SyncEngine can catch and route to onError,
+      // avoiding a silent fallback to expensive full-syncs.
+      rethrow;
     }
   }
 }

--- a/lib/src/queue_store.dart
+++ b/lib/src/queue_store.dart
@@ -12,6 +12,9 @@ abstract class QueueStore {
   /// Get pending (un-synced) entries, oldest first.
   Future<List<SyncEntry>> getPending({int limit = 50});
 
+  /// Check if a specific record has a pending sync entry.
+  Future<bool> hasPending(String table, String id);
+
   /// Mark an entry as successfully synced.
   Future<void> markSynced(String id);
 

--- a/lib/src/sync_engine.dart
+++ b/lib/src/sync_engine.dart
@@ -166,6 +166,11 @@ class SyncEngine {
       for (final row in rows) {
         final id = row['id']?.toString();
         if (id == null) continue;
+
+        // Skip overwriting local data if there is a pending user edit.
+        final isPending = await queue.hasPending(table, id);
+        if (isPending) continue;
+
         await local.upsert(table, id, row);
       }
       await timestamps.set(table, DateTime.now().toUtc());

--- a/lib/src/timestamp_store.dart
+++ b/lib/src/timestamp_store.dart
@@ -10,7 +10,11 @@ abstract class TimestampStore {
   Future<void> set(String table, DateTime timestamp);
 }
 
-/// In-memory timestamp store. Useful for testing.
+/// In-memory timestamp store.
+///
+/// **WARNING:** Do not use this in production! It resets on app launch,
+/// which will cause a full data pull (`pullSince` from epoch) every time.
+/// Use [DriftTimestampStore] or implement your own persistent store.
 class InMemoryTimestampStore implements TimestampStore {
   final _timestamps = <String, DateTime>{};
 


### PR DESCRIPTION
## Summary
- **SQL injection fix** — escape table/column names in `DriftLocalStore`
- **Race condition fix** — `hasPending()` check before pull-overwrite protects un-synced local edits
- **Dynamic userId** — `SupabaseRemoteStore.userId` is now `String Function()` to handle session expiry
- **Error propagation** — `getRemoteTimestamps()` rethrows instead of silent fallback to full-sync
- **InMemoryTimestampStore** — production warning added

## Test plan
- [ ] Verify SQL injection is blocked (malicious column/table names)
- [ ] Verify pending local edits survive a pull cycle
- [ ] Verify auth expiry doesn't push to wrong user
- [ ] Verify sync works without a `sync_status` table

Signed-off-by: Hassam Sheikh <hassam@dynos.app>

🤖 Generated with [Claude Code](https://claude.com/claude-code)