### PR TITLE
[autofix] [test_fragility_mismatched_mocks] Test 139: onPushBatch is configured to throw E

### DIFF
--- a/test/dynos_sync_total_audit_test.dart
+++ b/test/dynos_sync_total_audit_test.dart
@@ -6150,7 +6150,8 @@ void main() {
 
       remote.onPush = (_, __, ___, ____) async =>
           throw const AuthExpiredException('Token expired');
-      remote.onPushBatch = (_) async => throw Exception('Batch fail');
+      remote.onPushBatch = (_) async =>
+          throw const AuthExpiredException('Token expired');
 
       await queue.enqueue(SyncEntry(
         id: 'auth-patch',


### PR DESCRIPTION
## What's wrong

[test_fragility_mismatched_mocks] Test 139: onPushBatch is configured to throw Exception('Batch fail') while onPush throws AuthExpiredException. If the engine implementation calls pushBatch instead of push for this single queue entry, the test will receive the wrong exception type and expectations will fail. The test should either set both callbacks to throw the same exception or explicitly ensure only onPush is invoked.

**Where:** `test/dynos_sync_total_audit_test.dart:6147`
**Severity:** medium

## What this PR does

Fixes the issue above. The change was generated by the dynos-work autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
test/dynos_sync_total_audit_test.dart | 3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)
```

## Evidence

```json
{
  "file": "test/dynos_sync_total_audit_test.dart",
  "line": 6147,
  "category_detail": "test_fragility_mismatched_mocks",
  "reviewer": "haiku"
}
```

---
*Auto-generated by [dynos-work](https://github.com/dynos-fit/dynos-work) proactive scanner.*