### PR TITLE
[autofix] [Data integrity - unhandled deserialization exception] jsonDecode() throws an un

### DIFF
--- a/lib/src/adapters/drift_queue_store.dart
+++ b/lib/src/adapters/drift_queue_store.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'package:drift/drift.dart';
 import '../queue_store.dart';
 import '../sync_entry.dart';
+import '../sync_exceptions.dart';
 import '../sync_operation.dart';
 
 /// [QueueStore] implementation backed by a Drift [DynosSyncQueueTable].
@@ -139,7 +140,7 @@ class DriftQueueStore implements QueueStore {
       table: row.read<String>('table_name'),
       recordId: row.read<String>('record_id'),
       operation: SyncOperation.values.byName(row.read<String>('operation')),
-      payload: jsonDecode(row.read<String>('payload')) as Map<String, dynamic>,
+      payload: _decodePayload(row.read<String>('payload')),
       createdAt: DateTime.fromMillisecondsSinceEpoch(
         row.read<int>('created_at'),
         isUtc: true,
@@ -158,5 +159,13 @@ class DriftQueueStore implements QueueStore {
             )
           : null,
     );
+  }
+
+  static Map<String, dynamic> _decodePayload(String raw) {
+    try {
+      return jsonDecode(raw) as Map<String, dynamic>;
+    } on FormatException catch (e) {
+      throw SyncDeserializationException(e);
+    }
   }
 }


### PR DESCRIPTION
## What's wrong

[Data integrity - unhandled deserialization exception] jsonDecode() throws an unhandled exception if the payload column contains invalid JSON, causing the sync operation to crash.

**Where:** `lib/src/adapters/drift_queue_store.dart:129`
**Severity:** medium

## What this PR does

Fixes the issue above. The change was generated by the dynos-work autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
lib/src/adapters/drift_queue_store.dart | 11 ++++++++++-
 1 file changed, 10 insertions(+), 1 deletion(-)
```

## Evidence

```json
{
  "file": "lib/src/adapters/drift_queue_store.dart",
  "line": 129,
  "category_detail": "Data integrity - unhandled deserialization exception",
  "reviewer": "haiku"
}
```

---
*Auto-generated by [dynos-work](https://github.com/dynos-fit/dynos-work) proactive scanner.*