### PR TITLE
[autofix] [Syntax error] Orphaned @override method definition at module level between Mock

### DIFF
--- a/test/flood_stress_test.dart
+++ b/test/flood_stress_test.dart
@@ -9,9 +9,6 @@ class MockRemoteStore extends Mock implements RemoteStore {}
 
 class MockLocalStore extends Mock implements LocalStore {}
 
-@override
-Future<void> clearAll(List<String> t) async {}
-
 class MockQueueStore extends Mock implements QueueStore {}
 
 class MockTimestampStore extends Mock implements TimestampStore {}

--- a/test/penetration_test.dart
+++ b/test/penetration_test.dart
@@ -8,9 +8,6 @@ class MockRemoteStore extends Mock implements RemoteStore {}
 
 class MockLocalStore extends Mock implements LocalStore {}
 
-@override
-Future<void> clearAll(List<String> t) async {}
-
 class MockQueueStore extends Mock implements QueueStore {}
 
 class MockTimestampStore extends Mock implements TimestampStore {}

--- a/test/performance_benchmark_test.dart
+++ b/test/performance_benchmark_test.dart
@@ -8,9 +8,6 @@ class MockRemoteStore extends Mock implements RemoteStore {}
 
 class MockLocalStore extends Mock implements LocalStore {}
 
-@override
-Future<void> clearAll(List<String> t) async {}
-
 class MockQueueStore extends Mock implements QueueStore {}
 
 class MockTimestampStore extends Mock implements TimestampStore {}


### PR DESCRIPTION
## What's wrong

[Syntax error] Orphaned @override method definition at module level between MockLocalStore and MockQueueStore classes will cause a compilation error.

**Where:** `test/performance_benchmark_test.dart:16`
**Severity:** critical

## What this PR does

Fixes the issue above. The change was generated by the dynos-work autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
test/flood_stress_test.dart          | 3 ---
 test/penetration_test.dart           | 3 ---
 test/performance_benchmark_test.dart | 3 ---
 3 files changed, 9 deletions(-)
```

## Evidence

```json
{
  "file": "test/performance_benchmark_test.dart",
  "line": 16,
  "category_detail": "Syntax error",
  "reviewer": "haiku"
}
```

---
*Auto-generated by [dynos-work](https://github.com/dynos-fit/dynos-work) proactive scanner.*