### PR TITLE
[autofix] [Logic bug in test mock] FastInMemoryQueue.hasPending() always returns false reg

### DIFF
--- a/test/performance_benchmark_test.dart
+++ b/test/performance_benchmark_test.dart
@@ -42,7 +42,8 @@ class FastInMemoryQueue implements QueueStore {
       .toList()
     ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
   @override
-  Future<bool> hasPending(String t, String id) async => false;
+  Future<bool> hasPending(String t, String id) async =>
+      _queue.any((e) => e.table == t && e.recordId == id && e.isPending);
   @override
   Future<void> markSynced(String id) async {}
   @override


### PR DESCRIPTION
## What's wrong

[Logic bug in test mock] FastInMemoryQueue.hasPending() always returns false regardless of queue state; should check if any pending entries exist for the given table and record ID.

**Where:** `test/performance_benchmark_test.dart:44`
**Severity:** medium

## What this PR does

Fixes the issue above. The change was generated by the dynos-work autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
test/performance_benchmark_test.dart | 3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)
```

## Evidence

```json
{
  "file": "test/performance_benchmark_test.dart",
  "line": 44,
  "category_detail": "Logic bug in test mock",
  "reviewer": "haiku"
}
```

---
*Auto-generated by [dynos-work](https://github.com/dynos-fit/dynos-work) proactive scanner.*