### PR TITLE
[autofix] [Test flakiness] Benchmark timing assertions (lessThan(3000)ms) are fragile and 

### DIFF
--- a/test/flood_stress_test.dart
+++ b/test/flood_stress_test.dart
@@ -94,8 +94,8 @@ void main() {
           'Frequency: ${(100000 / (sw.elapsedMilliseconds / 1000)).floor()} writes/sec');
 
       expect(queue.count, 100000);
-      expect(
-          sw.elapsedMilliseconds, lessThan(10000)); // Must ingest 100k in < 10s
+      // Timing assertion removed: absolute ms thresholds are fragile and
+      // environment-dependent. The prints above surface regressions in CI logs.
     });
 
     test('Engine stability under RLS-Bypass Flood Attempt', () async {

--- a/test/performance_benchmark_test.dart
+++ b/test/performance_benchmark_test.dart
@@ -92,7 +92,8 @@ void main() {
 
       print(
           'BENCHMARK: 100,000 Writes (Local + Queue) took: ${sw.elapsedMilliseconds}ms');
-      expect(sw.elapsedMilliseconds, lessThan(3000));
+      // Timing assertion removed: absolute ms thresholds are fragile and
+      // environment-dependent. The print above surfaces regressions in CI logs.
     });
 
     test('Batch Push Drain Performance (100k Records)', () async {
@@ -173,7 +174,8 @@ void main() {
 
       print(
           'BENCHMARK: Pulling 100,000 records (delta-sync) took: ${sw.elapsedMilliseconds}ms');
-      expect(sw.elapsedMilliseconds, lessThan(3000));
+      // Timing assertion removed: absolute ms thresholds are fragile and
+      // environment-dependent. The print above surfaces regressions in CI logs.
     });
   });
 }


### PR DESCRIPTION
## What's wrong

[Test flakiness] Benchmark timing assertions (lessThan(3000)ms) are fragile and environment-dependent; timing tests can fail unpredictably on slow systems or under load.

**Where:** `test/performance_benchmark_test.dart:73`
**Severity:** low

## What this PR does

Fixes the issue above. The change was generated by the dynos-work autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
test/flood_stress_test.dart          | 4 ++--
 test/performance_benchmark_test.dart | 6 ++++--
 2 files changed, 6 insertions(+), 4 deletions(-)
```

## Evidence

```json
{
  "file": "test/performance_benchmark_test.dart",
  "line": 73,
  "category_detail": "Test flakiness",
  "reviewer": "haiku"
}
```

---
*Auto-generated by [dynos-work](https://github.com/dynos-fit/dynos-work) proactive scanner.*