### PR TITLE
[autofix] [Data integrity — operation order mismatch] Operation order violates documented 

### DIFF
--- a/lib/src/sync_engine.dart
+++ b/lib/src/sync_engine.dart
@@ -187,11 +187,11 @@ class SyncEngine {
 
   /// Delete a record locally and queue the deletion for push.
   Future<void> remove(String table, String id) async {
-    // 1. Queue deletion
-    await _enqueue(table, id, SyncOperation.delete, {});
-
-    // 2. Remove locally
+    // 1. Remove locally first — if this fails, nothing is queued
     await local.delete(table, id);
+
+    // 2. Queue deletion for remote sync
+    await _enqueue(table, id, SyncOperation.delete, {});
   }
 
   /// Queue a push without writing locally.


### PR DESCRIPTION
## What's wrong

[Data integrity — operation order mismatch] Operation order violates documented contract. remove() queues delete first (line 195), then removes locally (line 198). If local.delete() fails, the delete is queued but the record still exists locally, leaving the local and queued states inconsistent.

**Where:** `lib/src/sync_engine.dart:195`
**Severity:** high

## What this PR does

Fixes the issue above. The change was generated by the dynos-work autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
lib/src/sync_engine.dart | 8 ++++----
 1 file changed, 4 insertions(+), 4 deletions(-)
```

## Evidence

```json
{
  "file": "lib/src/sync_engine.dart",
  "line": 195,
  "category_detail": "Data integrity \u2014 operation order mismatch",
  "reviewer": "haiku"
}
```

---
*Auto-generated by [dynos-work](https://github.com/dynos-fit/dynos-work) proactive scanner.*