### PR TITLE
[autofix] [Error handling gap — state consistency] Missing error handling in addTable(). I

### DIFF
--- a/lib/src/sync_engine.dart
+++ b/lib/src/sync_engine.dart
@@ -68,8 +68,13 @@ class SyncEngine {
     if (_tables.contains(table)) return false;
     _tables.add(table);
     if (pull) {
-      final since = await timestamps.get(table);
-      await _pullTable(table, since);
+      try {
+        final since = await timestamps.get(table);
+        await _pullTable(table, since);
+      } catch (_) {
+        _tables.remove(table);
+        rethrow;
+      }
     }
     return true;
   }


### PR DESCRIPTION
## What's wrong

[Error handling gap — state consistency] Missing error handling in addTable(). If _pullTable() throws (line 75), the exception propagates but the table is already added to _tables (line 72), leaving the engine in an inconsistent state (table registered but data not pulled).

**Where:** `lib/src/sync_engine.dart:72`
**Severity:** medium

## What this PR does

Fixes the issue above. The change was generated by the dynos-work autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
lib/src/sync_engine.dart | 9 +++++++--
 1 file changed, 7 insertions(+), 2 deletions(-)
```

## Evidence

```json
{
  "file": "lib/src/sync_engine.dart",
  "line": 72,
  "category_detail": "Error handling gap \u2014 state consistency",
  "reviewer": "haiku"
}
```

---
*Auto-generated by [dynos-work](https://github.com/dynos-fit/dynos-work) proactive scanner.*