### PR TITLE
[autofix] [test logic — async/await mismatch] Test 30 uses synchronous expect pattern for 

### DIFF
--- a/test/dynos_sync_total_audit_test.dart
+++ b/test/dynos_sync_total_audit_test.dart
@@ -1289,8 +1289,8 @@ void main() {
       final hugeValue = 'x' * (50 * 1024 * 1024);
       final hugePayload = {'blob': hugeValue};
 
-      expect(
-        () => engine.write('uploads', 'u1', hugePayload),
+      await expectLater(
+        engine.write('uploads', 'u1', hugePayload),
         throwsA(isA<PayloadTooLargeException>()),
         reason: '50MB payload must trigger PayloadTooLargeException',
       );


### PR DESCRIPTION
## What's wrong

[test logic — async/await mismatch] Test 30 uses synchronous expect pattern for async function. The lambda `() => engine.write(...)` returns a Future without throwing synchronously, so `throwsA` won't catch the async exception. Must pass the Future directly to expect without a lambda wrapper.

**Where:** `test/dynos_sync_total_audit_test.dart:1300`
**Severity:** high

## What this PR does

Fixes the issue above. The change was generated by the dynos-work autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
test/dynos_sync_total_audit_test.dart | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```

## Evidence

```json
{
  "file": "test/dynos_sync_total_audit_test.dart",
  "line": 1300,
  "category_detail": "test logic \u2014 async/await mismatch",
  "reviewer": "haiku"
}
```

---
*Auto-generated by [dynos-work](https://github.com/dynos-fit/dynos-work) proactive scanner.*