### PR TITLE
[autofix] [async/await correctness] Same async issue: engine.push() is not awaited. The ex

### DIFF
--- a/test/dynos_sync_total_audit_test.dart
+++ b/test/dynos_sync_total_audit_test.dart
@@ -6010,7 +6010,7 @@ void main() {
         config: const SyncConfig(maxPayloadBytes: 100),
       );
 
-      expect(
+      await expectLater(
         () => engine.push(
           'tasks',
           't-1',
@@ -6036,7 +6036,7 @@ void main() {
         userId: 'user-A',
       );
 
-      expect(
+      await expectLater(
         () => engine.push(
           'tasks',
           't-1',


### PR DESCRIPTION
## What's wrong

[async/await correctness] Same async issue: engine.push() is not awaited. The expect() will receive a Future, not a thrown exception. Pattern should be 'await engine.push(...)' or use an async lambda if expect() supports it.

**Where:** `test/dynos_sync_total_audit_test.dart:5989`
**Severity:** high

## What this PR does

Fixes the issue above. The change was generated by the dynos-work autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
test/dynos_sync_total_audit_test.dart | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```

## Evidence

```json
{
  "file": "test/dynos_sync_total_audit_test.dart",
  "line": 5989,
  "category_detail": "async/await correctness",
  "reviewer": "haiku"
}
```

---
*Auto-generated by [dynos-work](https://github.com/dynos-fit/dynos-work) proactive scanner.*