### PR TITLE
[autofix] [error handling] remote.pushedPayloads.last will throw IndexError if the list is

### DIFF
--- a/test/dynos_sync_total_audit_test.dart
+++ b/test/dynos_sync_total_audit_test.dart
@@ -6077,6 +6077,7 @@ void main() {
       });
 
       // Check what was pushed to remote
+      expect(remote.pushedPayloads, isNotEmpty);
       expect(remote.pushedPayloads.last['diagnosis'], '[REDACTED]',
           reason: 'Sensitive fields must be masked before push');
       expect(remote.pushedPayloads.last['department'], 'Cardiology');


### PR DESCRIPTION
## What's wrong

[error handling] remote.pushedPayloads.last will throw IndexError if the list is empty, masking the real test failure. Should guard with 'expect(remote.pushedPayloads, isNotEmpty)' before accessing .last.

**Where:** `test/dynos_sync_total_audit_test.dart:6030`
**Severity:** medium

## What this PR does

Fixes the issue above. The change was generated by the dynos-work autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
test/dynos_sync_total_audit_test.dart | 1 +
 1 file changed, 1 insertion(+)
```

## Evidence

```json
{
  "file": "test/dynos_sync_total_audit_test.dart",
  "line": 6030,
  "category_detail": "error handling",
  "reviewer": "haiku"
}
```

---
*Auto-generated by [dynos-work](https://github.com/dynos-fit/dynos-work) proactive scanner.*