### PR TITLE
[autofix] [logic_error] Test 24 creates SyncEngine with ConflictStrategy.lastWriteWins but

### DIFF
--- a/test/security_suite_test.dart
+++ b/test/security_suite_test.dart
@@ -1086,9 +1086,12 @@ void main() {
 
       final conflicts = events.whereType<SyncConflict>().toList();
       expect(conflicts, isNotEmpty);
-      // Delete should win — strategy should be clientWins
+      // SyncEngine._resolveConflict has a special case: when the local
+      // pending entry is a DELETE, it always resolves as clientWins
+      // regardless of the configured conflictStrategy (lastWriteWins here).
       expect(conflicts.first.strategyUsed, ConflictStrategy.clientWins,
-          reason: 'DELETE operation wins over remote update');
+          reason:
+              'DELETE override: local delete always wins over remote update');
     });
 
     test(


### PR DESCRIPTION
## What's wrong

[logic_error] Test 24 creates SyncEngine with ConflictStrategy.lastWriteWins but expects strategyUsed to be ConflictStrategy.clientWins. Assertion at line 1048 expects 'clientWins' strategy for a DELETE vs UPDATE conflict, but the engine configuration (line 1033) specifies 'lastWriteWins'. This is a mismatch between configured strategy and expected strategy unless the implementation has undocumented special-case handling for DELETE operations that overrides the configured strategy.

**Where:** `test/security_suite_test.dart:1048`
**Severity:** high

## What this PR does

Fixes the issue above. The change was generated by the dynos-work autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
test/security_suite_test.dart | 7 +++++--
 1 file changed, 5 insertions(+), 2 deletions(-)
```

## Evidence

```json
{
  "file": "test/security_suite_test.dart",
  "line": 1048,
  "category_detail": "logic_error",
  "reviewer": "haiku"
}
```

---
*Auto-generated by [dynos-work](https://github.com/dynos-fit/dynos-work) proactive scanner.*