### PR TITLE
[autofix] [Test incompleteness - missing critical test step] Test 30 does not call drain()

### DIFF
--- a/test/security_suite_test.dart
+++ b/test/security_suite_test.dart
@@ -1312,9 +1312,25 @@ void main() {
         await engine.write('tasks', 'task-$i', {'val': i});
       }
 
-      // Should not throw — engine is stable
       expect(queue.allEntries.length, 100,
           reason: 'All 100 entries must be in the queue (no data loss)');
+
+      // Drain to trigger the onPush handler with alternating failures
+      await engine.drain();
+
+      // Verify the engine actually processed entries under alternating failures
+      expect(callIdx, greaterThan(0),
+          reason: 'drain() must have invoked the push handler');
+      final syncedCount =
+          queue.allEntries.where((e) => e.syncedAt != null).length;
+      final pendingCount =
+          queue.allEntries.where((e) => e.isPending).length;
+      expect(syncedCount + pendingCount, 100,
+          reason: 'No entries lost after drain with alternating failures');
+      expect(syncedCount, greaterThan(0),
+          reason: 'Some entries should have synced on even-numbered calls');
+      expect(pendingCount, greaterThan(0),
+          reason: 'Some entries should remain pending from odd-numbered failures');
     });
 
     test('31. Concurrent writes during drain: new records not in current batch',


### PR DESCRIPTION
## What's wrong

[Test incompleteness - missing critical test step] Test 30 does not call drain() to trigger the onPush handler with alternating failures. Test name claims to test 'success/failure toggling' but the toggles never execute. The test only verifies queue entries exist; it doesn't verify the engine behavior under alternating push failures.

**Where:** `test/security_suite_test.dart:1315`
**Severity:** medium

## What this PR does

Fixes the issue above. The change was generated by the dynos-work autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
test/security_suite_test.dart | 18 +++++++++++++++++-
 1 file changed, 17 insertions(+), 1 deletion(-)
```

## Evidence

```json
{
  "file": "test/security_suite_test.dart",
  "line": 1315,
  "category_detail": "Test incompleteness - missing critical test step",
  "reviewer": "haiku"
}
```

---
*Auto-generated by [dynos-work](https://github.com/dynos-fit/dynos-work) proactive scanner.*