### PR TITLE
[autofix] [test_validity_async_exception_matching] Test 41: expect() with throwsA matcher 

### DIFF
--- a/test/security_suite_test.dart
+++ b/test/security_suite_test.dart
@@ -1741,7 +1741,7 @@ void main() {
       // One byte over — should throw
       final overPayload = {'d': 'x' * (padSize + 1)};
       expect(
-        () => engine.write('tasks', 't2', overPayload),
+        () async => await engine.write('tasks', 't2', overPayload),
         throwsA(isA<PayloadTooLargeException>()),
       );
     });


### PR DESCRIPTION
## What's wrong

[test_validity_async_exception_matching] Test 41: expect() with throwsA matcher on async function closure will not catch the exception. The closure () => engine.write(...) returns a Future but throwsA expects a synchronous throw. The test will pass even if PayloadTooLargeException is never thrown. Should use () async => await engine.write(...) or await the call and catch manually.

**Where:** `test/security_suite_test.dart:1751`
**Severity:** high

## What this PR does

Fixes the issue above. The change was generated by the dynos-work autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
test/security_suite_test.dart | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

## Evidence

```json
{
  "file": "test/security_suite_test.dart",
  "line": 1751,
  "category_detail": "test_validity_async_exception_matching",
  "reviewer": "haiku"
}
```

---
*Auto-generated by [dynos-work](https://github.com/dynos-fit/dynos-work) proactive scanner.*