### PR TITLE
[autofix] [Syntax error] Orphaned @override annotation and method definition at module lev

### DIFF
--- a/test/performance_benchmark_test.dart
+++ b/test/performance_benchmark_test.dart
@@ -8,9 +8,6 @@ class MockRemoteStore extends Mock implements RemoteStore {}
 
 class MockLocalStore extends Mock implements LocalStore {}
 
-@override
-Future<void> clearAll(List<String> t) async {}
-
 class MockQueueStore extends Mock implements QueueStore {}
 
 class MockTimestampStore extends Mock implements TimestampStore {}


### PR DESCRIPTION
## What's wrong

[Syntax error] Orphaned @override annotation and method definition at module level after MockLocalStore class closure (line 9-10) — this is a syntax error that will prevent the file from compiling.

**Where:** `test/performance_benchmark_test.dart:9`
**Severity:** critical

## What this PR does

Fixes the issue above. The change was generated by the dynos-work autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
test/performance_benchmark_test.dart | 3 ---
 1 file changed, 3 deletions(-)
```

## Evidence

```json
{
  "file": "test/performance_benchmark_test.dart",
  "line": 9,
  "category_detail": "Syntax error",
  "reviewer": "haiku"
}
```

---
*Auto-generated by [dynos-work](https://github.com/dynos-fit/dynos-work) proactive scanner.*