### PR TITLE
[autofix] [Test reliability] FastInMemoryLocal implements LocalStore but all methods (clea

### DIFF
--- a/test/performance_benchmark_test.dart
+++ b/test/performance_benchmark_test.dart
@@ -59,12 +59,14 @@ class FastInMemoryQueue implements QueueStore {
 }
 
 class FastInMemoryLocal implements LocalStore {
+  final _data = <String, Map<String, dynamic>>{};
   @override
-  Future<void> clearAll(List<String> t) async {}
+  Future<void> clearAll(List<String> t) async => _data.clear();
   @override
-  Future<void> upsert(String n, String i, Map<String, dynamic> d) async {}
+  Future<void> upsert(String n, String i, Map<String, dynamic> d) async =>
+      _data['$n:$i'] = d;
   @override
-  Future<void> delete(String n, String i) async {}
+  Future<void> delete(String n, String i) async => _data.remove('$n:$i');
 }
 
 void main() {


### PR DESCRIPTION
## What's wrong

[Test reliability] FastInMemoryLocal implements LocalStore but all methods (clearAll, upsert, delete) are empty no-ops — it does not store or retrieve any data, making tests using this mock unable to verify local persistence behavior.

**Where:** `test/performance_benchmark_test.dart:45`
**Severity:** high

## What this PR does

Fixes the issue above. The change was generated by the dynos-work autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
test/performance_benchmark_test.dart | 8 +++++---
 1 file changed, 5 insertions(+), 3 deletions(-)
```

## Evidence

```json
{
  "file": "test/performance_benchmark_test.dart",
  "line": 45,
  "category_detail": "Test reliability",
  "reviewer": "haiku"
}
```

---
*Auto-generated by [dynos-work](https://github.com/dynos-fit/dynos-work) proactive scanner.*