### PR TITLE
[autofix] [Incomplete test setup] MockRemoteStore and MockTimestampStore are created but n

### DIFF
--- a/test/performance_benchmark_test.dart
+++ b/test/performance_benchmark_test.dart
@@ -67,6 +67,28 @@ class FastInMemoryLocal implements LocalStore {
   Future<void> delete(String n, String i) async {}
 }
 
+class FastInMemoryRemote implements RemoteStore {
+  @override
+  Future<void> push(String t, String id, SyncOperation op,
+      Map<String, dynamic> data) async {}
+  @override
+  Future<void> pushBatch(List<SyncEntry> entries) async {}
+  @override
+  Future<List<Map<String, dynamic>>> pullSince(
+          String table, DateTime since) async =>
+      [];
+  @override
+  Future<Map<String, DateTime>> getRemoteTimestamps() async => {};
+}
+
+class FastInMemoryTimestamp implements TimestampStore {
+  @override
+  Future<DateTime> get(String t) async =>
+      DateTime.fromMillisecondsSinceEpoch(0, isUtc: true);
+  @override
+  Future<void> set(String t, DateTime ts) async {}
+}
+
 void main() {
   setUpAll(() {
     registerFallbackValue(SyncOperation.upsert);
@@ -78,9 +100,9 @@ void main() {
       final queue = FastInMemoryQueue();
       final engine = SyncEngine(
         local: FastInMemoryLocal(),
-        remote: MockRemoteStore(),
+        remote: FastInMemoryRemote(),
         queue: queue,
-        timestamps: MockTimestampStore(),
+        timestamps: FastInMemoryTimestamp(),
         tables: ['tasks'],
       );
 


### PR DESCRIPTION
## What's wrong

[Incomplete test setup] MockRemoteStore and MockTimestampStore are created but never configured with when() stubs in 'Optimistic Write Throughput' test (lines 59-65) — they will return null/default values, making the test not exercise realistic remote store behavior.

**Where:** `test/performance_benchmark_test.dart:59`
**Severity:** medium

## What this PR does

Fixes the issue above. The change was generated by the dynos-work autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
test/performance_benchmark_test.dart | 26 ++++++++++++++++++++++++--
 1 file changed, 24 insertions(+), 2 deletions(-)
```

## Evidence

```json
{
  "file": "test/performance_benchmark_test.dart",
  "line": 59,
  "category_detail": "Incomplete test setup",
  "reviewer": "haiku"
}
```

---
*Auto-generated by [dynos-work](https://github.com/dynos-fit/dynos-work) proactive scanner.*