### PR TITLE
[autofix] [data integrity: queue/local store divergence] Data integrity gap: if local.upse

### DIFF
--- a/lib/src/sync_engine.dart
+++ b/lib/src/sync_engine.dart
@@ -165,8 +165,9 @@ class SyncEngine {
 
   /// Write a record locally and queue it for push to the remote.
   ///
-  /// **Military Grade Fix:** Operation is now explicitly ordered to ensure
-  /// the sync queue entry exists before the local write completes.
+  /// Local write runs first so a failed upsert never leaves an orphaned
+  /// queue entry.  If `local.upsert` throws, no entry is enqueued and the
+  /// caller receives the error.
   Future<void> write(
     String table,
     String id,
@@ -178,20 +179,23 @@ class SyncEngine {
     // Validate payload size after scrubbing (just in case)
     _validatePayloadSize(maskedData);
 
-    // 1. Queue it (includes RLS check)
-    await _enqueue(table, id, SyncOperation.upsert, maskedData);
-
-    // 2. Write it locally
+    // 1. Write locally first — fail fast before touching the queue
     await local.upsert(table, id, maskedData);
+
+    // 2. Queue it for remote push (includes RLS check)
+    await _enqueue(table, id, SyncOperation.upsert, maskedData);
   }
 
   /// Delete a record locally and queue the deletion for push.
+  ///
+  /// Local delete runs first so a failed delete never leaves an orphaned
+  /// queue entry.
   Future<void> remove(String table, String id) async {
-    // 1. Queue deletion
-    await _enqueue(table, id, SyncOperation.delete, {});
-
-    // 2. Remove locally
+    // 1. Remove locally first — fail fast before touching the queue
     await local.delete(table, id);
+
+    // 2. Queue deletion for remote push
+    await _enqueue(table, id, SyncOperation.delete, {});
   }
 
   /// Queue a push without writing locally.


### PR DESCRIPTION
## What's wrong

[data integrity: queue/local store divergence] Data integrity gap: if local.upsert() fails after _enqueue() succeeds in write(), the queue contains an entry for an operation whose local effect did not occur. Subsequent syncs will attempt to push queued data that doesn't exist in the local store, potentially causing data loss or sync failures.

**Where:** `lib/src/sync_engine.dart:148`
**Severity:** medium

## What this PR does

Fixes the issue above. The change was generated by the dynos-work autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
lib/src/sync_engine.dart | 24 ++++++++++++++----------
 1 file changed, 14 insertions(+), 10 deletions(-)
```

## Evidence

```json
{
  "file": "lib/src/sync_engine.dart",
  "line": 148,
  "category_detail": "data integrity: queue/local store divergence",
  "reviewer": "haiku"
}
```

---
*Auto-generated by [dynos-work](https://github.com/dynos-fit/dynos-work) proactive scanner.*