### PR TITLE
[autofix] [security - PII exposure] push() method enqueues data without masking PII, unlik

### DIFF
--- a/lib/src/sync_engine.dart
+++ b/lib/src/sync_engine.dart
@@ -204,10 +204,13 @@ class SyncEngine {
     Map<String, dynamic> data, {
     SyncOperation operation = SyncOperation.upsert,
   }) async {
-    // Validate payload size before anything
-    _validatePayloadSize(data);
+    // Scrub PII before anything else (matches write() behavior)
+    final maskedData = _maskPayload(data);
 
-    await _enqueue(table, id, operation, data);
+    // Validate payload size after scrubbing
+    _validatePayloadSize(maskedData);
+
+    await _enqueue(table, id, operation, maskedData);
   }
 
   // ── Drain (push pending) ──────────────────────────────────────────────────

--- a/test/dynos_sync_total_audit_test.dart
+++ b/test/dynos_sync_total_audit_test.dart
@@ -6069,8 +6069,7 @@ void main() {
         config: const SyncConfig(sensitiveFields: ['diagnosis']),
       );
 
-      // write() masks sensitive fields; push() does not (by design —
-      // push() is for callers who handle masking themselves).
+      // Both write() and push() mask sensitive fields via _maskPayload().
       await engine.write('patients', 'p-1', {
         'diagnosis': 'Hypertension',
         'department': 'Cardiology',

--- a/test/patch_operation_test.dart
+++ b/test/patch_operation_test.dart
@@ -274,7 +274,7 @@ void main() {
         config: const SyncConfig(sensitiveFields: ['email']),
       );
 
-      // write() applies PII masking; push() does not (by design).
+      // write() and push() both apply PII masking via _maskPayload().
       await engine.write('profiles', 'p-1', {
         'email': 'new@email.com',
         'display_name': 'Updated',


### PR DESCRIPTION
## What's wrong

[security - PII exposure] push() method enqueues data without masking PII, unlike write(). If push() is called with sensitive data and an error occurs during sync, the raw PII could be exposed in queue entries. The write() method masks via _maskPayload() before enqueuing, but push() skips this step.

**Where:** `lib/src/sync_engine.dart:201`
**Severity:** high

## What this PR does

Fixes the issue above. The change was generated by the dynos-work autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
lib/src/sync_engine.dart              | 9 ++++++---
 test/dynos_sync_total_audit_test.dart | 3 +--
 test/patch_operation_test.dart        | 2 +-
 3 files changed, 8 insertions(+), 6 deletions(-)
```

## Evidence

```json
{
  "file": "lib/src/sync_engine.dart",
  "line": 201,
  "category_detail": "security - PII exposure",
  "reviewer": "haiku"
}
```

---
*Auto-generated by [dynos-work](https://github.com/dynos-fit/dynos-work) proactive scanner.*