### PR TITLE
[autofix][llm-review][medium] [race condition / timing issue] Test 9 uses Duration.zero which does not provide

### DIFF
--- a/test/dynos_sync_total_audit_test.dart
+++ b/test/dynos_sync_total_audit_test.dart
@@ -549,7 +549,7 @@ void main() {
       engine.events.listen(events.add);
 
       await engine.write('patients', 'p1', {'name': 'Test'});
-      await Future<void>.delayed(Duration.zero);
+      await engine.drain();
 
       final authEvents = events.whereType<SyncAuthRequired>().toList();
       expect(authEvents, isNotEmpty,


### PR DESCRIPTION
## What's wrong

[race condition / timing issue] Test 9 uses Duration.zero which does not provide sufficient time for async push operation to complete before checking for SyncAuthRequired event. The engine.write() is awaited, but the subsequent push() that triggers AuthExpiredException is asynchronous and may not have completed when the event check occurs. This creates a race condition where the assertion may intermittently fail.

**Where:** `test/dynos_sync_total_audit_test.dart:545`
**Severity:** medium

## What this PR does

Fixes the issue above. The change was generated by the dynos-work autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
test/dynos_sync_total_audit_test.dart | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

## Evidence

```json
{
  "file": "test/dynos_sync_total_audit_test.dart",
  "line": 545,
  "category_detail": "race condition / timing issue",
  "reviewer": "haiku"
}
```

---
*Auto-generated by [dynos-work](https://github.com/dynos-fit/dynos-work) proactive scanner.*