### PR TITLE
[autofix][llm-review][high] [Test double implementation bug] hasPending() always returns false regardless of

### DIFF
--- a/test/performance_benchmark_test.dart
+++ b/test/performance_benchmark_test.dart
@@ -42,7 +42,8 @@ class FastInMemoryQueue implements QueueStore {
       .toList()
     ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
   @override
-  Future<bool> hasPending(String t, String id) async => false;
+  Future<bool> hasPending(String t, String id) async =>
+      _queue.any((e) => e.table == t && e.recordId == id && e.isPending);
   @override
   Future<void> markSynced(String id) async {}
   @override


### PR DESCRIPTION
## What's wrong

[Test double implementation bug] hasPending() always returns false regardless of queue state, diverging from the interface contract and potentially masking engine bugs that depend on this method for control flow.

**Where:** `test/performance_benchmark_test.dart:42`
**Severity:** high

## What this PR does

Fixes the issue above. The change was generated by the dynos-work autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
test/performance_benchmark_test.dart | 3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)
```

## Evidence

```json
{
  "file": "test/performance_benchmark_test.dart",
  "line": 42,
  "category_detail": "Test double implementation bug",
  "reviewer": "haiku"
}
```

---
*Auto-generated by [dynos-work](https://github.com/dynos-fit/dynos-work) proactive scanner.*