### PR TITLE
[autofix][llm-review][high] [security/data_handling] PII data not masked in push() method before enqueueing.

### DIFF
--- a/lib/src/sync_engine.dart
+++ b/lib/src/sync_engine.dart
@@ -204,10 +204,13 @@ class SyncEngine {
     Map<String, dynamic> data, {
     SyncOperation operation = SyncOperation.upsert,
   }) async {
-    // Validate payload size before anything
-    _validatePayloadSize(data);
+    // 🛡️ Scrub PII before anything else
+    final maskedData = _maskPayload(data);
 
-    await _enqueue(table, id, operation, data);
+    // Validate payload size after scrubbing
+    _validatePayloadSize(maskedData);
+
+    await _enqueue(table, id, operation, maskedData);
   }
 
   // ── Drain (push pending) ──────────────────────────────────────────────────
@@ -331,7 +334,7 @@ class SyncEngine {
       for (final table in tables) {
         final remoteTime = remoteTs[table];
         if (remoteTime == null) {
-          // No remote timestamp — pull unconditionally with epoch
+          // No remote timestamp — pull unconditionally (defaults to epoch if never synced)
           pulls.add(_pullTable(table, await timestamps.get(table)));
           continue;
         }

--- a/test/dynos_sync_total_audit_test.dart
+++ b/test/dynos_sync_total_audit_test.dart
@@ -6069,8 +6069,7 @@ void main() {
         config: const SyncConfig(sensitiveFields: ['diagnosis']),
       );
 
-      // write() masks sensitive fields; push() does not (by design —
-      // push() is for callers who handle masking themselves).
+      // write() masks sensitive fields; push() also masks (security fix).
       await engine.write('patients', 'p-1', {
         'diagnosis': 'Hypertension',
         'department': 'Cardiology',

--- a/test/patch_operation_test.dart
+++ b/test/patch_operation_test.dart
@@ -274,7 +274,7 @@ void main() {
         config: const SyncConfig(sensitiveFields: ['email']),
       );
 
-      // write() applies PII masking; push() does not (by design).
+      // write() applies PII masking; push() also masks (security fix).
       await engine.write('profiles', 'p-1', {
         'email': 'new@email.com',
         'display_name': 'Updated',


### PR DESCRIPTION
## What's wrong

[security/data_handling] PII data not masked in push() method before enqueueing. The write() method masks payload with _maskPayload() before enqueuing (line 170), but push() passes unmasked data directly to _enqueue() (line 194). This creates a data security gap where PII could leak if callers don't mask externally-sourced data themselves.

**Where:** `lib/src/sync_engine.dart:194`
**Severity:** high

## What this PR does

Fixes the issue above. The change was generated by the autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
lib/src/sync_engine.dart              | 11 +++++++----
 test/dynos_sync_total_audit_test.dart |  3 +--
 test/patch_operation_test.dart        |  2 +-
 3 files changed, 9 insertions(+), 7 deletions(-)
```

## Evidence

```json
{
  "file": "lib/src/sync_engine.dart",
  "line": 194,
  "category_detail": "security/data_handling",
  "reviewer": "haiku"
}
```

---
*Auto-generated by [autofix-scanner](https://github.com/dynos-fit/autofix) proactive scanner.*