### PR TITLE
[autofix][llm-review][medium] [logic bug / unused parameter] purgeSynced declares a retention parameter but ne

### DIFF
--- a/test/dynos_sync_total_audit_test.dart
+++ b/test/dynos_sync_total_audit_test.dart
@@ -120,8 +120,11 @@ class InMemoryQueueStore implements QueueStore {
 
   @override
   Future<void> purgeSynced(
-          {Duration retention = const Duration(days: 30)}) async =>
-      _queue.removeWhere((e) => !e.isPending);
+      {Duration retention = const Duration(days: 30)}) async {
+    final cutoff = DateTime.now().toUtc().subtract(retention);
+    _queue.removeWhere(
+        (e) => e.syncedAt != null && e.syncedAt!.isBefore(cutoff));
+  }
 
   @override
   Future<void> clearAll() async => _queue.clear();


### PR DESCRIPTION
## What's wrong

[logic bug / unused parameter] purgeSynced declares a retention parameter but never uses it. The method removes all non-pending entries regardless of retention period, contradicting the API contract.

**Where:** `test/dynos_sync_total_audit_test.dart:125`
**Severity:** medium

## What this PR does

Fixes the issue above. The change was generated by the autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
test/dynos_sync_total_audit_test.dart | 7 +++++--
 1 file changed, 5 insertions(+), 2 deletions(-)
```

## Evidence

```json
{
  "file": "test/dynos_sync_total_audit_test.dart",
  "line": 125,
  "category_detail": "logic bug / unused parameter",
  "reviewer": "haiku"
}
```

---
*Auto-generated by [autofix-scanner](https://github.com/dynos-fit/autofix) proactive scanner.*