### PR TITLE
[autofix][llm-review][medium] [logic_bug] purgeSynced() accepts a retention Duration parameter but never uses 

### DIFF
--- a/test/dynos_sync_total_audit_test.dart
+++ b/test/dynos_sync_total_audit_test.dart
@@ -120,8 +120,11 @@ class InMemoryQueueStore implements QueueStore {
 
   @override
   Future<void> purgeSynced(
-          {Duration retention = const Duration(days: 30)}) async =>
-      _queue.removeWhere((e) => !e.isPending);
+      {Duration retention = const Duration(days: 30)}) async {
+    final cutoff = DateTime.now().toUtc().subtract(retention);
+    _queue.removeWhere(
+        (e) => !e.isPending && e.syncedAt != null && e.syncedAt!.isBefore(cutoff));
+  }
 
   @override
   Future<void> clearAll() async => _queue.clear();


### PR DESCRIPTION
## What's wrong

[logic_bug] purgeSynced() accepts a retention Duration parameter but never uses it. The method always removes all non-pending entries regardless of retention duration, which violates the intended contract and could mask data retention bugs in tests.

**Where:** `test/dynos_sync_total_audit_test.dart:107`
**Severity:** medium

## What this PR does

Fixes the issue above. The change was generated by the autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
test/dynos_sync_total_audit_test.dart | 7 +++++--
 1 file changed, 5 insertions(+), 2 deletions(-)
```

## Evidence

```json
{
  "file": "test/dynos_sync_total_audit_test.dart",
  "line": 107,
  "category_detail": "logic_bug",
  "reviewer": "haiku"
}
```

---
*Auto-generated by [autofix-scanner](https://github.com/dynos-fit/autofix) proactive scanner.*