### PR TITLE
[autofix][llm-review][medium] [logic_bug] purgeSynced() method ignores the 'retention' parameter. It removes a

### DIFF
--- a/test/dynos_sync_total_audit_test.dart
+++ b/test/dynos_sync_total_audit_test.dart
@@ -120,8 +120,11 @@ class InMemoryQueueStore implements QueueStore {
 
   @override
   Future<void> purgeSynced(
-          {Duration retention = const Duration(days: 30)}) async =>
-      _queue.removeWhere((e) => !e.isPending);
+      {Duration retention = const Duration(days: 30)}) async {
+    final cutoff = DateTime.now().toUtc().subtract(retention);
+    _queue.removeWhere((e) =>
+        e.syncedAt != null && !e.syncedAt!.isAfter(cutoff));
+  }
 
   @override
   Future<void> clearAll() async => _queue.clear();
@@ -2808,7 +2811,10 @@ void main() {
         queue: queue,
         timestamps: InMemoryTimestampStore(),
         tables: ['tasks'],
-        config: const SyncConfig(batchSize: 50),
+        config: const SyncConfig(
+          batchSize: 50,
+          queueRetention: Duration.zero,
+        ),
       );
 
       // Make best-effort push fail so entries stay pending for drain


### PR DESCRIPTION
## What's wrong

[logic_bug] purgeSynced() method ignores the 'retention' parameter. It removes all non-pending entries regardless of age, but the parameter suggests entries older than the retention duration should be removed. Either the parameter is unused (misleading signature) or the implementation is incomplete.

**Where:** `test/dynos_sync_total_audit_test.dart:105`
**Severity:** medium

## What this PR does

Fixes the issue above. The change was generated by the autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
test/dynos_sync_total_audit_test.dart | 12 +++++++++---
 1 file changed, 9 insertions(+), 3 deletions(-)
```

## Evidence

```json
{
  "file": "test/dynos_sync_total_audit_test.dart",
  "line": 105,
  "category_detail": "logic_bug",
  "reviewer": "haiku"
}
```

---
*Auto-generated by [autofix-scanner](https://github.com/dynos-fit/autofix) proactive scanner.*